### PR TITLE
Merge icoderaven's feature/device_mem_extension

### DIFF
--- a/source/gRenderKernel/main_renderkernel.cpp
+++ b/source/gRenderKernel/main_renderkernel.cpp
@@ -30,7 +30,7 @@
 CUmodule		cuCustom;
 CUfunction		cuRaycastKernel;
 
-bool cudaCheck ( CUresult status, char* msg )
+bool cudaCheck ( CUresult status, const char* msg )
 {
 	if ( status != CUDA_SUCCESS ) {
 		const char* stat = "";

--- a/source/gvdb_library/kernels/cuda_gvdb_copydata.cu
+++ b/source/gvdb_library/kernels/cuda_gvdb_copydata.cu
@@ -35,12 +35,12 @@ texture<float, cudaTextureType3D, cudaReadModeElementType>		volTexInF;
 surface<void, cudaTextureType3D>								volTexOut;
 
 // Zero memory of 3D volume
-extern "C" __global__ void kernelFillTex ( int3 res, int dsize )
+extern "C" __global__ void kernelFillTex ( int3 res, int dsize, float init_val )
 {
 	uint3 t = blockIdx * make_uint3(blockDim.x, blockDim.y, blockDim.z) + threadIdx;	
 	if ( t.x >= res.x || t.y >= res.y || t.z >= res.z ) return;
 
-	surf3Dwrite ( 0, volTexOut, t.x*dsize, t.y, t.z );
+	surf3Dwrite ( init_val, volTexOut, t.x*dsize, t.y, t.z );
 }
 
 // Copy 3D texture into sub-volume of another 3D texture (char)

--- a/source/gvdb_library/kernels/cuda_gvdb_nodes.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_nodes.cuh
@@ -78,6 +78,8 @@ struct ALIGN(16) VDBInfo {
 	float3		bmax;	
 	cudaTextureObject_t		volIn[MAX_CHANNEL];
 	cudaSurfaceObject_t		volOut[MAX_CHANNEL];	
+	char*		atlas_dev_mem[MAX_CHANNEL];
+	bool		use_tex_mem[MAX_CHANNEL];
 };
 
 __device__ float								cdebug[256]; 

--- a/source/gvdb_library/kernels/cuda_gvdb_operators.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_operators.cuh
@@ -464,7 +464,17 @@ extern "C" __global__ void gvdbOpFillF  ( VDBInfo* gvdb, int3 res, uchar chan, f
 		v += sinf( vox.z*12/(3.141592*30.0) );
 		surf3Dwrite ( v, gvdb->volOut[chan], vox.x*sizeof(float), vox.y, vox.z );
 	} else {
-		surf3Dwrite ( p1, gvdb->volOut[chan], vox.x*sizeof(float), vox.y, vox.z );
+		if(gvdb->use_tex_mem[chan]){
+			surf3Dwrite(p1, gvdb->volOut[chan], vox.x * sizeof(float), vox.y, vox.z);					// Write to apron voxel
+		}
+		else{
+			uint3 vox_fixed = vox - make_uint3(1, 1, 1);
+			int3 atlas_res = gvdb->atlas_res;
+			unsigned long int atlas_id = vox_fixed.z * atlas_res.x * atlas_res.y +
+                               vox_fixed.y * atlas_res.x + vox_fixed.x;
+			float* atlas_mem = (float*)(gvdb->atlas_dev_mem[chan]) + atlas_id;
+			*atlas_mem = p1;
+		}
 	}
 }
 extern "C" __global__ void gvdbOpFillC4 ( VDBInfo* gvdb, int3 res, uchar chan, float p1, float p2, float p3 )

--- a/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
@@ -530,7 +530,8 @@ __device__ void rayCast ( VDBInfo* gvdb, uchar chan, float3 pos, float3 dir, flo
 
 		// depth buffer test [optional]
 		if (SCN_DBUF != 0x0) {
-			if (t.x > getLinearDepth(SCN_DBUF) ) {
+			float dist = t.x * dot(scn.dir_vec, dir);
+			if (dist > getLinearDepth(SCN_DBUF) ) {
 				hit.z = 0;
 				return;
 			}

--- a/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
@@ -470,7 +470,8 @@ __device__ void rayDeepBrick ( VDBInfo* gvdb, uchar chan, int nodeid, float3 t, 
 
 		// depth buffer test [optional]
 		if (SCN_DBUF != 0x0) {
-			if (t.x > getLinearDepth(SCN_DBUF) ) {
+			float dist = t.x * fabsf(dot(scn.dir_vec, normalize(dir)));
+			if (dist > getLinearDepth(SCN_DBUF) ) {
 				hit.y = length(wp - pos);
 				hit.z = 1;
 				clr = make_float4(fmin(clr.x, 1.f), fmin(clr.y, 1.f), fmin(clr.z, 1.f), fmax(clr.w, 0.f));
@@ -506,6 +507,8 @@ __device__ void rayCast ( VDBInfo* gvdb, uchar chan, float3 pos, float3 dir, flo
 	int		nodeid[MAXLEV];					// level variables
 	float	tMax[MAXLEV];
 	int		b;	
+	// Normalize incoming ray direction
+	dir = normalize(dir);
 
 	// GVDB - Iterative Hierarchical 3DDA on GPU
 	float3 vmin;	
@@ -530,7 +533,7 @@ __device__ void rayCast ( VDBInfo* gvdb, uchar chan, float3 pos, float3 dir, flo
 
 		// depth buffer test [optional]
 		if (SCN_DBUF != 0x0) {
-			float dist = t.x * dot(scn.dir_vec, dir);
+			float dist = t.x * fabsf(dot(scn.dir_vec, normalize(dir)));
 			if (dist > getLinearDepth(SCN_DBUF) ) {
 				hit.z = 0;
 				return;

--- a/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_raycast.cuh
@@ -470,7 +470,7 @@ __device__ void rayDeepBrick ( VDBInfo* gvdb, uchar chan, int nodeid, float3 t, 
 
 		// depth buffer test [optional]
 		if (SCN_DBUF != 0x0) {
-			float dist = t.x * fabsf(dot(scn.dir_vec, normalize(dir)));
+			float dist = t.x * fabsf(dot(scn.dir_vec, dir));
 			if (dist > getLinearDepth(SCN_DBUF) ) {
 				hit.y = length(wp - pos);
 				hit.z = 1;

--- a/source/gvdb_library/kernels/cuda_gvdb_scene.cuh
+++ b/source/gvdb_library/kernels/cuda_gvdb_scene.cuh
@@ -78,6 +78,7 @@ struct ALIGN(16) ScnInfo {
 	float4*		transfer;
 	char*		outbuf;
   	char*   	dbuf;	
+	float3		dir_vec ;
 };
 
 struct ALIGN(16) ScnRay {

--- a/source/gvdb_library/src/app_perf.cpp
+++ b/source/gvdb_library/src/app_perf.cpp
@@ -169,7 +169,7 @@ void PERF_SET ( bool cons, int lev )
 	g_perfPrintLev = lev;
 }
 
-void PERF_INIT ( int buildbits, bool cpu, bool gpu, bool cons, int lev, char* fname )
+void PERF_INIT ( int buildbits, bool cpu, bool gpu, bool cons, int lev, const char* fname )
 {
 	g_perfCPU = cpu;
 	g_perfGPU = gpu;

--- a/source/gvdb_library/src/app_perf.h
+++ b/source/gvdb_library/src/app_perf.h
@@ -69,7 +69,7 @@
 	extern "C" GVDB_API float PERF_POP ();
 	extern "C" GVDB_API void PERF_START ();
 	extern "C" GVDB_API float PERF_STOP ();
-	extern "C" GVDB_API void PERF_INIT ( int buildbits, bool cpu, bool gpu, bool cons, int lev, char* fname );
+	extern "C" GVDB_API void PERF_INIT ( int buildbits, bool cpu, bool gpu, bool cons, int lev, const char* fname );
 	extern "C" GVDB_API void PERF_SET ( bool cons, int lev );
 	extern "C" GVDB_API void PERF_PRINTF ( char* format, ... );
 

--- a/source/gvdb_library/src/gvdb_allocator.cpp
+++ b/source/gvdb_library/src/gvdb_allocator.cpp
@@ -453,6 +453,30 @@ void Allocator::AllocateTextureCPU ( DataPtr& p, uint64 sz, bool bCPU, uint64 pr
 	}
 }
 
+void Allocator::AllocateAtlasMemGPU(DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve) {
+  if (!bGL) {
+    // Cache old address
+    CUdeviceptr old_array = p.gpu;
+
+    if (res.x > 0 && res.y > 0 && res.z > 0) {
+      // Allocate new linear memory according to the size required
+	  printf("Allocating device memory of size %u bytes\n", p.size);
+      cudaCheck(cuMemAlloc(&p.gpu, p.size), "Allocator", "AllocateAtlasMemGPU", "cuMemAlloc", "", mbDebug);
+      if (preserve > 0 && old_array != 0) {
+        // Clear channel to 0
+        cudaCheck(cuMemsetD8(p.gpu, 0, p.size), "Allocator", "AllocateAtlasMemGPU", "cuMemset", "", mbDebug);
+
+        // Copy over preserved data
+        if (preserve>0 && preserve < res.x * res.y * res.z)
+          cudaCheck(cuMemcpyDtoD(p.gpu, old_array, preserve), "Allocator", "AllocateAtlasMemGPU", "cuMemcpyDtoD", "preserve", mbDebug);
+      }
+    } else {
+      p.gpu = 0;
+    }
+    if (old_array != 0) cudaCheck(cuMemFree(old_array), "Allocator", "AllocateAtlasMemGPU", "cuMemFree", "", mbDebug);
+  }
+}
+
 void Allocator::AllocateAtlasMap ( int stride, Vector3DI axiscnt )
 {
 	DataPtr q; 
@@ -502,6 +526,7 @@ bool Allocator::TextureCreate ( uchar chan, uchar dtype, Vector3DI res, bool bCP
 	AllocateTextureGPU ( p, dtype, res, bGL, 0 );		// GPU allocate	
 	AllocateTextureCPU ( p, p.size, bCPU, 0 );			// CPU allocate	
 	mAtlas.push_back ( p );
+	mAtlasTexMem.push_back ( true );
 
 	cudaCheck ( cuCtxSynchronize(), "Allocator", "TextureCreate", "cuCtxSynchronize", "", mbDebug);
 
@@ -510,7 +535,7 @@ bool Allocator::TextureCreate ( uchar chan, uchar dtype, Vector3DI res, bool bCP
 
 
 
-bool Allocator::AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL )
+bool Allocator::AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL , bool use_tex_mem)
 {
 	Vector3DI axisres;
 	uint64 atlas_sz; 
@@ -535,9 +560,15 @@ bool Allocator::AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector
 	p.garray = 0x0;
 
 	// Atlas
-	AllocateTextureGPU ( p, dtype, axisres, bGL, 0 );		// GPU allocate	
+	if(use_tex_mem){
+		AllocateTextureGPU ( p, dtype, axisres, bGL, 0 );		// GPU allocate	
+	}
+	else{
+		AllocateAtlasMemGPU( p, dtype, axisres, bGL, 0 );
+	}
 	AllocateTextureCPU ( p, p.size, bCPU, 0 );				// CPU allocate
 	mAtlas.push_back ( p );
+	mAtlasTexMem.push_back ( use_tex_mem );
 
 	cudaCheck ( cuCtxSynchronize(), "Allocator", "AtlasCreate", "cuCtxSynchronize", "", mbDebug);
 
@@ -558,7 +589,7 @@ void Allocator::AtlasSetNum ( uchar chan, int n )
 	mAtlas[chan].lastEle = n;
 }
 
-bool Allocator::AtlasResize ( uchar chan, int cx, int cy, int cz )
+bool Allocator::AtlasResize ( uchar chan, int cx, int cy, int cz)
 {
 	DataPtr p = mAtlas[chan];
 	int leafdim = p.stride;
@@ -573,7 +604,12 @@ bool Allocator::AtlasResize ( uchar chan, int cx, int cy, int cz )
 	p.subdim = axiscnt;
 
 	// Atlas		
-	AllocateTextureGPU ( p, p.type, axisres, (p.glid!=-1), 0 );
+	if(mAtlasTexMem[chan]){
+		AllocateTextureGPU ( p, p.type, axisres, (p.glid!=-1), 0 );
+	}
+	else{
+		AllocateAtlasMemGPU( p, p.type, axisres, (p.glid!=-1), 0 );
+	}
 	AllocateTextureCPU ( p, p.size, (p.cpu!=0x0), 0 );
 	mAtlas[chan] = p;
 
@@ -584,24 +620,32 @@ void Allocator::CopyChannel(int chanDst, int chanSrc)
 {
 	DataPtr pDst = mAtlas[chanDst];
 	DataPtr pSrc = mAtlas[chanSrc];
+	if(mAtlasTexMem[chanDst] != mAtlasTexMem[chanSrc]){
+		gprintf("Invalid channels attempted to be copied!");
+	}
+	if(mAtlasTexMem[chanDst]){
+		int leafdim = pSrc.stride;	
+		Vector3DI axisres;
+		Vector3DI axiscnt = pSrc.subdim;	// number of bricks on each axis	
+		uint64 preserve = pSrc.size;		// previous size of atlas (# bytes to preserve)
 
-	int leafdim = pSrc.stride;	
-	Vector3DI axisres;
-	Vector3DI axiscnt = pSrc.subdim;	// number of bricks on each axis	
-	uint64 preserve = pSrc.size;		// previous size of atlas (# bytes to preserve)
+		axisres = axiscnt * int(leafdim + pSrc.apron * 2);		
 
-	axisres = axiscnt * int(leafdim + pSrc.apron * 2);		
-
-	CUDA_MEMCPY3D cp = {0};
-	cp.dstMemoryType = CU_MEMORYTYPE_ARRAY;
-	cp.dstArray = pDst.garray;
-	cp.srcMemoryType = CU_MEMORYTYPE_ARRAY;
-	cp.srcArray = pSrc.garray;
-	cp.WidthInBytes = axisres.x * getSize(pSrc.type);
-	cp.Height = axisres.y;
-	cp.Depth = preserve / (axisres.x*axisres.y*getSize(pSrc.type));	  // amount to copy (preserve)
-	
-	cudaCheck ( cuMemcpy3D ( &cp ), "Allocator", "CopyChannel", "cuMemcpy3D", "", mbDebug);
+		CUDA_MEMCPY3D cp = {0};
+		cp.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+		cp.dstArray = pDst.garray;
+		cp.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+		cp.srcArray = pSrc.garray;
+		cp.WidthInBytes = axisres.x * getSize(pSrc.type);
+		cp.Height = axisres.y;
+		cp.Depth = preserve / (axisres.x*axisres.y*getSize(pSrc.type));	  // amount to copy (preserve)
+		
+		cudaCheck ( cuMemcpy3D ( &cp ), "Allocator", "CopyChannel", "cuMemcpy3D", "", mbDebug);
+	}
+	else{
+		uint64 preserve = pSrc.size;
+		cudaCheck( cuMemcpyDtoD( pDst.gpu, pSrc.gpu, preserve), "Allocator", "CopyChannel", "cuMemcpyDtoD", "preserve", mbDebug);
+	}
 }
 
 bool Allocator::AtlasResize ( uchar chan, uint64 max_leaf )
@@ -626,8 +670,13 @@ bool Allocator::AtlasResize ( uchar chan, uint64 max_leaf )
 	p.size = atlas_sz;				// new total # bytes
 	p.subdim = axiscnt;				// new number of bricks on each axis
 
-	// Atlas		
-	AllocateTextureGPU ( p, p.type, axisres, (p.glid!=-1), preserve );
+	// Atlas	
+	if(mAtlasTexMem[chan]){
+		AllocateTextureGPU ( p, p.type, axisres, (p.glid!=-1), preserve );
+	}
+	else{
+		AllocateAtlasMemGPU( p, p.type, axisres, (p.glid!=-1), preserve );
+	}
 	AllocateTextureCPU ( p, p.size, (p.cpu!=0x0), preserve );
 	mAtlas[chan] = p;
 
@@ -807,56 +856,70 @@ void Allocator::AtlasCommitFromCPU ( uchar chan, uchar* src )
 
 void Allocator::AtlasFill ( uchar chan )
 {
-	Vector3DI atlasres = getAtlasRes(chan);	
-	Vector3DI block ( 8, 8, 8 );
-	Vector3DI grid ( int(atlasres.x/block.x)+1, int(atlasres.y/block.y)+1, int(atlasres.z/block.z)+1 );	
-	
-	cudaCheck ( cuSurfRefSetArray( cuSurfWrite, reinterpret_cast<CUarray>(mAtlas[chan].garray), 0 ), "Allocator", "AtlasCommitFromCPU", "cuSurfRefSetArray", "cuSurfWrite", mbDebug);
-	int dsize = getSize( mAtlas[chan].type );
-	void* args[2] = { &atlasres, &dsize };
-	cudaCheck ( cuLaunchKernel ( cuFillTex, grid.x, grid.y, grid.z, block.x, block.y, block.z, 0, mStream, args, NULL ), "Allocator", "AtlasCommitFromCPU", "cuLaunch", "cuFillTex", mbDebug);
+	if(mAtlasTexMem[chan]){
+		Vector3DI atlasres = getAtlasRes(chan);	
+		Vector3DI block ( 8, 8, 8 );
+		Vector3DI grid ( int(atlasres.x/block.x)+1, int(atlasres.y/block.y)+1, int(atlasres.z/block.z)+1 );	
+		
+		cudaCheck ( cuSurfRefSetArray( cuSurfWrite, reinterpret_cast<CUarray>(mAtlas[chan].garray), 0 ), "Allocator", "AtlasCommitFromCPU", "cuSurfRefSetArray", "cuSurfWrite", mbDebug);
+		int dsize = getSize( mAtlas[chan].type );
+		void* args[2] = { &atlasres, &dsize };
+		cudaCheck ( cuLaunchKernel ( cuFillTex, grid.x, grid.y, grid.z, block.x, block.y, block.z, 0, mStream, args, NULL ), "Allocator", "AtlasCommitFromCPU", "cuLaunch", "cuFillTex", mbDebug);
+	}
+	else{
+		cudaCheck( cuMemsetD8(mAtlas[chan].gpu, 0, mAtlas[chan].size), "Allocator", "AtlasCommitFromCPU", "cuMemset", "", mbDebug);
+	}
 }
 
 void Allocator::AtlasRetrieveSlice ( uchar chan, int slice, int sz, CUdeviceptr gpu_buf, uchar* cpu_dest )
 {
-	// transfer a 3D texture slice into gpu buffer
-	Vector3DI atlasres = getAtlasRes(chan);
-	Vector3DI block ( 8, 8, 1 );
-	Vector3DI grid ( int(atlasres.x/block.x)+1, int(atlasres.y/block.y)+1, 1 );	
-	void* args[3] = { &slice, &atlasres, &gpu_buf };
+	if(mAtlasTexMem[chan]){
+		// transfer a 3D texture slice into gpu buffer
+		Vector3DI atlasres = getAtlasRes(chan);
+		Vector3DI block ( 8, 8, 1 );
+		Vector3DI grid ( int(atlasres.x/block.x)+1, int(atlasres.y/block.y)+1, 1 );	
+		void* args[3] = { &slice, &atlasres, &gpu_buf };
 
-	CUDA_MEMCPY3D cp = {0};	
-	cp.srcMemoryType = CU_MEMORYTYPE_ARRAY;
-	cp.srcArray = mAtlas[chan].garray;	
-	cp.srcZ = slice;
-	cp.dstMemoryType = CU_MEMORYTYPE_HOST;
-	cp.dstHost = cpu_dest;
-	cp.WidthInBytes = atlasres.x * getSize( mAtlas[chan].type );
-	cp.Height = atlasres.y;
-	cp.Depth = 1;
-	cudaCheck ( cuMemcpy3D ( &cp ), "Allocator", "AtlasRetrieveSlice", "cuMemcpy3D", "", mbDebug);
+		CUDA_MEMCPY3D cp = {0};	
+		cp.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+		cp.srcArray = mAtlas[chan].garray;	
+		cp.srcZ = slice;
+		cp.dstMemoryType = CU_MEMORYTYPE_HOST;
+		cp.dstHost = cpu_dest;
+		cp.WidthInBytes = atlasres.x * getSize( mAtlas[chan].type );
+		cp.Height = atlasres.y;
+		cp.Depth = 1;
+		cudaCheck ( cuMemcpy3D ( &cp ), "Allocator", "AtlasRetrieveSlice", "cuMemcpy3D", "", mbDebug);
+	}
+	else{
+		cudaCheck( cuMemcpyDtoH( (void *) cpu_dest, mAtlas[chan].gpu + slice * sz, sz), "Allocator", "AtlasRetrieveSlice", "cuMemcpyDtoH", "", mbDebug);
+	}
 }
 
 void Allocator::AtlasWriteSlice ( uchar chan, int slice, int sz, CUdeviceptr gpu_buf, uchar* cpu_src )
 {
-	// transfer from gpu buffer into 3D texture slice 
-	Vector3DI atlasres = getAtlasRes(chan);
-	Vector3DI block ( 8, 8, 1 );
-	Vector3DI grid ( int(atlasres.x/block.x)+1, int(atlasres.y/block.y)+1, 1 );		
-	void* args[3] = { &slice, &atlasres, &gpu_buf };
+	if(mAtlasTexMem[chan]){
+		// transfer from gpu buffer into 3D texture slice 
+		Vector3DI atlasres = getAtlasRes(chan);
+		Vector3DI block ( 8, 8, 1 );
+		Vector3DI grid ( int(atlasres.x/block.x)+1, int(atlasres.y/block.y)+1, 1 );		
+		void* args[3] = { &slice, &atlasres, &gpu_buf };
 
 
-	CUDA_MEMCPY3D cp = {0};	
-	cp.dstMemoryType = CU_MEMORYTYPE_ARRAY;
-	cp.dstArray = mAtlas[chan].garray;	
-	cp.dstZ = slice;
-	cp.srcMemoryType = CU_MEMORYTYPE_HOST;
-	cp.srcHost = cpu_src;
-	cp.WidthInBytes = atlasres.x * getSize( mAtlas[chan].type );
-	cp.Height = atlasres.y;
-	cp.Depth = 1;
-	cudaCheck ( cuMemcpy3D ( &cp ), "Allocator", "AtlasWriteSlice", "cuMemcpy3D", "", mbDebug);
-
+		CUDA_MEMCPY3D cp = {0};	
+		cp.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+		cp.dstArray = mAtlas[chan].garray;	
+		cp.dstZ = slice;
+		cp.srcMemoryType = CU_MEMORYTYPE_HOST;
+		cp.srcHost = cpu_src;
+		cp.WidthInBytes = atlasres.x * getSize( mAtlas[chan].type );
+		cp.Height = atlasres.y;
+		cp.Depth = 1;
+		cudaCheck ( cuMemcpy3D ( &cp ), "Allocator", "AtlasWriteSlice", "cuMemcpy3D", "", mbDebug);
+	}
+	else{
+		cudaCheck( cuMemcpyHtoD( mAtlas[chan].gpu + slice * sz, (void *)cpu_src,  sz), "Allocator", "AtlasWriteSlice", "cuMemcpyHtoD", "", mbDebug);
+	}
 }
 
 void Allocator::AtlasRetrieveGL ( uchar chan, char* dest )
@@ -906,9 +969,17 @@ void Allocator::AtlasReleaseAll ()
 			mAtlas[n].grsc = 0x0;
 		}
 		// Free cuda memory
-		if ( mAtlas[n].garray != 0x0 && mAtlas[n].glid == -1) {
-			cudaCheck ( cuArrayDestroy ( mAtlas[n].garray ), "Allocator", "AtlasReleaseAll", "cuArrayDestroy", "", mbDebug);
-			mAtlas[n].garray = 0x0;
+		if(mAtlasTexMem[n]){
+			if ( mAtlas[n].garray != 0x0 && mAtlas[n].glid == -1) {
+				cudaCheck ( cuArrayDestroy ( mAtlas[n].garray ), "Allocator", "AtlasReleaseAll", "cuArrayDestroy", "", mbDebug);
+				mAtlas[n].garray = 0x0;
+			}
+		}
+		else{
+			if ( mAtlas[n].gpu != 0x0 && mAtlas[n].glid == -1) {
+				cudaCheck ( cuMemFree ( mAtlas[n].gpu ), "Allocator", "AtlasReleaseAll", "cuMemFree", "", mbDebug);
+				mAtlas[n].gpu = 0x0;
+			}
 		}
 		// Free opengl memory	
 		#ifdef BUILD_OPENGL
@@ -920,6 +991,7 @@ void Allocator::AtlasReleaseAll ()
 	}
 
 	mAtlas.clear ();
+	mAtlasTexMem.clear ();
 
 	for (int n=0; n < mAtlasMap.size(); n++ )  {
 		// Free cpu memory

--- a/source/gvdb_library/src/gvdb_allocator.cpp
+++ b/source/gvdb_library/src/gvdb_allocator.cpp
@@ -460,7 +460,7 @@ void Allocator::AllocateAtlasMemGPU(DataPtr& p, uchar dtype, Vector3DI res, bool
 
     if (res.x > 0 && res.y > 0 && res.z > 0) {
       // Allocate new linear memory according to the size required
-	  printf("Allocating device memory of size %u bytes\n", p.size);
+	  // printf("Allocating device memory of size %u bytes\n", p.size);
       cudaCheck(cuMemAlloc(&p.gpu, p.size), "Allocator", "AllocateAtlasMemGPU", "cuMemAlloc", "", mbDebug);
       if (preserve > 0 && old_array != 0) {
         // Clear channel to 0
@@ -1062,7 +1062,7 @@ void Allocator::AtlasRead ( FILE* fp, uchar chan, uint64 asize )
 }
 #include <assert.h>
 
-bool cudaCheck ( CUresult launch_stat, char* obj, char* method, char* apicall, char* arg, bool bDebug)
+bool cudaCheck ( CUresult launch_stat, const char* obj, const char* method, const char* apicall, const char* arg, bool bDebug)
 {
 	CUresult kern_stat = CUDA_SUCCESS;
 	

--- a/source/gvdb_library/src/gvdb_allocator.h
+++ b/source/gvdb_library/src/gvdb_allocator.h
@@ -113,8 +113,11 @@
 		void	AllocateTextureGPU ( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve );
 		void	AllocateTextureCPU ( DataPtr& p, uint64 sz, bool bCPU, uint64 preserve );		
 
+		// Custom Extension for allocating device memory instead of texture
+		void 	AllocateAtlasMemGPU( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve );
+
 		// Atlas functions
-		bool	AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL );		
+		bool	AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL , bool use_tex_mem = true );		
 		bool	AtlasResize ( uchar chan, uint64 max_leaf );
 		bool	AtlasResize ( uchar chan, int cx, int cy, int cz );
 		void	AtlasSetNum ( uchar chan, int n );
@@ -161,6 +164,7 @@
 		int		getSize ( uchar dtype );
 		int		getNumAtlas ()					{ return (int) mAtlas.size(); }
 		DataPtr	getAtlas ( uchar chan )			{ return mAtlas[chan]; }	
+		bool 	getAtlasTexMem ( uchar chan )	{ return mAtlasTexMem[chan]; }	
 		float*	getAtlasCPU ( uchar chan )		{ return (float*) mAtlas[chan].cpu; }
 		int		getAtlasGLID ( uchar chan )		{ return mAtlas[chan].glid; }
 		uint64  getAtlasSize ( uchar chan )		{ return (uint64) mAtlas[chan].size; }
@@ -185,6 +189,7 @@
 		std::vector< DataPtr >		mPool[ MAX_POOL ];
 		std::vector< DataPtr >		mAtlas;
 		std::vector< DataPtr >		mAtlasMap;
+		std::vector< bool >			mAtlasTexMem;
 		DataPtr						mNeighbors;
 		bool						mbDebug;
 

--- a/source/gvdb_library/src/gvdb_allocator.h
+++ b/source/gvdb_library/src/gvdb_allocator.h
@@ -110,14 +110,13 @@
 
 		// Texture functions
 		bool	TextureCreate ( uchar chan, uchar dtype, Vector3DI res, bool bCPU, bool bGL );
-		void	AllocateTextureGPU ( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve );
-		void	AllocateTextureCPU ( DataPtr& p, uint64 sz, bool bCPU, uint64 preserve );		
-
+		void	AllocateTextureGPU ( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve, Vector4DF init_val = {.0f, .0f, .0f, .0f} );
+		void	AllocateTextureCPU ( DataPtr& p, uint64 sz, bool bCPU, uint64 preserve, Vector4DF init_val = {.0f, .0f, .0f, .0f} );		
 		// Custom Extension for allocating device memory instead of texture
-		void 	AllocateAtlasMemGPU( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve );
+		void 	AllocateAtlasMemGPU( DataPtr& p, uchar dtype, Vector3DI res, bool bGL, uint64 preserve, Vector4DF init_val = {.0f, .0f, .0f, .0f} );
 
 		// Atlas functions
-		bool	AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL , bool use_tex_mem = true );		
+		bool	AtlasCreate ( uchar chan, uchar dtype, Vector3DI leafdim, Vector3DI axiscnt, char apr, uint64 map_wid, bool bCPU, bool bGL , bool use_tex_mem = true, Vector4DF init_val = {.0f, .0f, .0f, .0f} );		
 		bool	AtlasResize ( uchar chan, uint64 max_leaf );
 		bool	AtlasResize ( uchar chan, int cx, int cy, int cz );
 		void	AtlasSetNum ( uchar chan, int n );
@@ -190,6 +189,7 @@
 		std::vector< DataPtr >		mAtlas;
 		std::vector< DataPtr >		mAtlasMap;
 		std::vector< bool >			mAtlasTexMem;
+		std::vector< Vector4DF >	mAtlasInitVal;
 		DataPtr						mNeighbors;
 		bool						mbDebug;
 

--- a/source/gvdb_library/src/gvdb_allocator.h
+++ b/source/gvdb_library/src/gvdb_allocator.h
@@ -37,7 +37,7 @@
 	#define MIN_RUNTIME_VERSION		4010
 	#define MIN_COMPUTE_VERSION		0x20
 	extern void				StartCuda( int devsel, CUcontext ctxsel, CUdevice& dev, CUcontext& ctx, CUstream* strm, bool verbose );
-	extern GVDB_API bool	cudaCheck ( CUresult e, char* obj, char* method, char* apicall, char* arg, bool bDebug);
+	extern GVDB_API bool	cudaCheck ( CUresult e, const char* obj, const char* method, const char* apicall, const char* arg, bool bDebug);
 	extern GVDB_API Vector3DF cudaGetMemUsage();
 
 	namespace nvdb {

--- a/source/gvdb_library/src/gvdb_camera.cpp
+++ b/source/gvdb_library/src/gvdb_camera.cpp
@@ -535,6 +535,7 @@ void Camera3D::setMatrices(const float* view_mtx, const float* proj_mtx, Vector3
 	mFov = 2.0f * atan(sx / mNear) / DEGtoRAD;
 
 	origRayWorld = from - model_pos;
+	dir_vec = inverseRayProj(0,0,mNear).Normalize();
 	updateFrustum();								// DO NOT call updateMatrices here. We have just set them.
 }
 

--- a/source/gvdb_library/src/gvdb_render.h
+++ b/source/gvdb_library/src/gvdb_render.h
@@ -55,7 +55,7 @@ using namespace nvdb;
 	#include <cudaGL.h>				// Cuda-GL interop
 	#include <cuda_gl_interop.h>
 	
-	GVDB_API void gchkGL( char* msg );
+	GVDB_API void gchkGL( const char* msg );
 
 	GVDB_API void renderCamSetupGL ( Scene* scene, int prog, Matrix4F* model );
 	GVDB_API void renderLightSetupGL ( Scene* scene, int prog );
@@ -67,12 +67,12 @@ using namespace nvdb;
 	GVDB_API void renderSetUW ( Scene* scene, int prog, Matrix4F* model, Vector3DF res );
 	GVDB_API void renderScreenspaceGL ( Scene* scene, int prog );
 
-	GVDB_API void makeSimpleShaderGL ( Scene* scene, char* vertfile, char* fragfile);
-	GVDB_API void makeSliceShader ( Scene* scene, char* vertname, char* fragname );
-	GVDB_API void makeOutlineShader ( Scene* scene, char* vertname, char* fragname );
-	GVDB_API void makeVoxelizeShader ( Scene* scene, char* vertname, char* fragname, char* geomname );
-	GVDB_API void makeRaycastShader ( Scene* scene, char* vertname, char* fragname );
-	GVDB_API void makeInstanceShader ( Scene* scene, char* vertname, char* fragname );
-	GVDB_API void makeScreenShader ( Scene* scene, char* vertname, char* fragname );
+	GVDB_API void makeSimpleShaderGL ( Scene* scene, const char* vertfile, const char* fragfile);
+	GVDB_API void makeSliceShader ( Scene* scene, const char* vertname, const char* fragname );
+	GVDB_API void makeOutlineShader ( Scene* scene, const char* vertname, const char* fragname );
+	GVDB_API void makeVoxelizeShader ( Scene* scene, const char* vertname, const char* fragname, const char* geomname );
+	GVDB_API void makeRaycastShader ( Scene* scene, const char* vertname, const char* fragname );
+	GVDB_API void makeInstanceShader ( Scene* scene, const char* vertname, const char* fragname );
+	GVDB_API void makeScreenShader ( Scene* scene, const char* vertname, const char* fragname );
 
 #endif

--- a/source/gvdb_library/src/gvdb_render_opengl.cpp
+++ b/source/gvdb_library/src/gvdb_render_opengl.cpp
@@ -24,7 +24,7 @@
 
 #ifdef BUILD_OPENGL
 
-	void gchkGL ( char* msg )
+	void gchkGL ( const char* msg )
 	{
 		GLenum errCode;
 		//const GLubyte* errString;
@@ -35,7 +35,7 @@
 		}
 	}
 
-	void makeSimpleShaderGL ( Scene* scene, char* vertname, char* fragname )
+	void makeSimpleShaderGL ( Scene* scene, const char* vertname, const char* fragname )
 	{
 		scene->AddShader ( GLS_SIMPLE, vertname, fragname );
 		scene->AddParam ( GLS_SIMPLE, UVIEW, "uView" );
@@ -45,7 +45,7 @@
 		scene->AddParam ( GLS_SIMPLE, UCLRAMB, "uClrAmb" );
 		scene->AddParam ( GLS_SIMPLE, UCLRDIFF, "uClrDiff" );		
 	}
-	void makeOutlineShader ( Scene* scene, char* vertname, char* fragname )
+	void makeOutlineShader ( Scene* scene, const char* vertname, const char* fragname )
 	{
 		scene->AddShader (GLS_OUTLINE, vertname, fragname );
 		scene->AddParam ( GLS_OUTLINE, UVIEW, "uView" );
@@ -54,7 +54,7 @@
 		scene->AddParam ( GLS_OUTLINE, UCLRAMB, "uClrAmb" );
 	}
 
-	void makeSliceShader ( Scene* scene, char* vertname, char* fragname )
+	void makeSliceShader ( Scene* scene, const char* vertname, const char* fragname )
 	{
 		scene->AddShader ( GLS_SLICE, vertname, fragname );
 		scene->AddParam ( GLS_SLICE, UVIEW, "uView" );
@@ -62,14 +62,14 @@
 		scene->AddParam ( GLS_SLICE, ULIGHTPOS, "uLightPos" );
 		scene->AddParam ( GLS_SLICE, UTEX, "uTex" );	
 	}
-	void makeVoxelizeShader ( Scene* scene, char* vertname, char* fragname, char* geomname )
+	void makeVoxelizeShader ( Scene* scene, const char* vertname, const char* fragname, const char* geomname )
 	{
 		scene->AddShader ( GLS_VOXELIZE, vertname, fragname, geomname );
 		scene->AddParam ( GLS_VOXELIZE, UW, "uW" );
 		scene->AddParam ( GLS_VOXELIZE, UTEXRES, "uTexRes" );
 		scene->AddParam ( GLS_VOXELIZE, USAMPLES, "uSamples" );
 	}
-	void makeRaycastShader ( Scene* scene, char* vertname, char* fragname )
+	void makeRaycastShader ( Scene* scene, const char* vertname, const char* fragname )
 	{
 		scene->AddShader ( GLS_RAYCAST, vertname, fragname );
 		scene->AddParam ( GLS_RAYCAST, UINVVIEW, "uInvView" );
@@ -82,7 +82,7 @@
 		scene->AddParam ( GLS_RAYCAST, ULIGHTPOS, "uLightPos" );
 		//scene->AddParam ( GLS_RAYCAST, USAMPLES, "uSamples" );
 	}
-	void makeInstanceShader ( Scene* scene, char* vertname, char* fragname )
+	void makeInstanceShader ( Scene* scene, const char* vertname, const char* fragname )
 	{
 		scene->AddShader ( GLS_INSTANCE, vertname, fragname );
 		scene->AddParam ( GLS_INSTANCE, UVIEW, "uView" );
@@ -94,7 +94,7 @@
 		scene->AddAttrib ( GLS_INSTANCE, UTEXMAX, "instTMax" );
 		scene->AddAttrib ( GLS_INSTANCE, UCLRAMB, "instClr" );*/
 	}
-	void makeScreenShader ( Scene* scene, char* vertname, char* fragname )
+	void makeScreenShader ( Scene* scene, const char* vertname, const char* fragname )
 	{
 		scene->AddShader ( GLS_SCREENTEX, vertname, fragname );
 		scene->AddParam ( GLS_SCREENTEX, UTEX,     "uTex" );	

--- a/source/gvdb_library/src/gvdb_scene.cpp
+++ b/source/gvdb_library/src/gvdb_scene.cpp
@@ -220,19 +220,19 @@ char *ReadShaderSource( char *fileName )
 }
 
 // Create a GLSL program object from vertex and fragment shader files
-int Scene::AddShader ( int prog_id, char* vertfile, char* fragfile )
+int Scene::AddShader ( int prog_id, const char* vertfile, const char* fragfile )
 {
 	return AddShader ( prog_id, vertfile, fragfile, 0x0 );
 }
 
 bool Scene::FindFile ( std::string fname, char* path )
 {
-	char fbuf[1024];
-	strcpy ( fbuf, fname.c_str() );
-	return getFileLocation ( fbuf, path, mSearchPaths );	
+	// char fbuf[1024];
+	// strcpy ( fbuf, fname.c_str() );
+	return getFileLocation ( fname.c_str(), path, mSearchPaths );	
 }
 
-int Scene::AddShader ( int prog_id, char* vertfile, char* fragfile, char* geomfile )
+int Scene::AddShader ( int prog_id, const char* vertfile, const char* fragfile, const char* geomfile )
 {
 	mLastShader = vertfile;
 	int maxLog = 65536, lenLog;
@@ -350,7 +350,7 @@ int	Scene::getSlot ( int prog_id )
 	return -1;
 }
 
-int	Scene::AddParam ( int prog_id, int id, char* name )
+int	Scene::AddParam ( int prog_id, int id, const char* name )
 {
 	int prog = mProgram[prog_id];
 	int active = 0;
@@ -365,7 +365,7 @@ int	Scene::AddParam ( int prog_id, int id, char* name )
 	return ndx;
 }
 
-int	Scene::AddAttrib ( int prog_id, int id, char* name )
+int	Scene::AddAttrib ( int prog_id, int id, const char* name )
 {
 	int prog = mProgram[prog_id];
 	//int ndx = glGetProgramResourceIndex ( prog, GL_BUFFER_VARIABLE, name );		

--- a/source/gvdb_library/src/gvdb_scene.h
+++ b/source/gvdb_library/src/gvdb_scene.h
@@ -86,10 +86,10 @@
 		void		LoadModel ( Model* m, std::string filestr, float scale, float tx, float ty, float tz );
 		
 		// Shaders
-		int			AddShader ( int prog_id, char* vertfile, char* fragfile );
-		int			AddShader ( int prog_id, char* vertfile, char* fragfile, char* geomfile );
-		int			AddParam (  int prog_id, int id, char* name );
-		int			AddAttrib ( int prog_id, int id, char* name );
+		int			AddShader ( int prog_id, const char* vertfile, const char* fragfile );
+		int			AddShader ( int prog_id, const char* vertfile, const char* fragfile, const char* geomfile );
+		int			AddParam (  int prog_id, int id, const char* name );
+		int			AddAttrib ( int prog_id, int id, const char* name );
 		int			getProgram(int prog_id) { return mProgram[prog_id]; }
 
 		// Materials
@@ -123,7 +123,7 @@
 		int			getNumLights()		{ return (int) mLights.size(); }
 		
 		// Loading scenes
-		void		Load ( char *filename, float windowAspect );
+		void		Load ( const char *filename, float windowAspect );
 		static void	LoadPath ();		
 		static void	LoadModel ();
 		static void	LoadVolume ();

--- a/source/gvdb_library/src/gvdb_types.h
+++ b/source/gvdb_library/src/gvdb_types.h
@@ -37,7 +37,7 @@
 			#if defined(_WIN32) || defined(__CYGWIN__)
 				#define GVDB_API		__declspec(dllimport)
 			#else
-				#define GVDB_API		__attribute__((dllimport))
+				#define GVDB_API		//https://stackoverflow.com/questions/2164827/explicitly-exporting-shared-library-functions-in-linux
 			#endif
 		#endif          
 	#else

--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -2655,7 +2655,7 @@ void VolumeGVDB::Configure ( int levs, int* r, int* numcnt, bool use_masks )
 }
 
 // Add a data channel (voxel attribute)
-void VolumeGVDB::AddChannel ( uchar chan, int dt, int apron, int filter, int border, Vector3DI axiscnt, bool use_tex_mem )
+void VolumeGVDB::AddChannel ( uchar chan, int dt, int apron, int filter, int border, Vector3DI axiscnt, bool use_tex_mem, Vector4DF init_val )
 {
 	PUSH_CTX
 
@@ -2665,7 +2665,7 @@ void VolumeGVDB::AddChannel ( uchar chan, int dt, int apron, int filter, int bor
 	}
 	mApron = apron;
 
-	mPool->AtlasCreate ( chan, dt, getRes3DI(0), axiscnt, apron, sizeof(AtlasNode), false, mbUseGLAtlas, use_tex_mem );
+	mPool->AtlasCreate ( chan, dt, getRes3DI(0), axiscnt, apron, sizeof(AtlasNode), false, mbUseGLAtlas, use_tex_mem, init_val );
 	mPool->AtlasSetFilter ( chan, filter, border );
 	SetupAtlasAccess ();	
 	POP_CTX

--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -4674,6 +4674,7 @@ void VolumeGVDB::PrepareRender ( int w, int h, char shading )
 	mScnInfo.outbuf		= -1;			// NOT USED  (was mRenderBuf[0].gpu;)
 	int dbuf = getScene()->getDepthBuf();
 	mScnInfo.dbuf 		= (dbuf == 255 ? NULL : mRenderBuf[dbuf].gpu);	
+	mScnInfo.dir_vec	= cam->dir_vec;
 
 	cudaCheck ( cuMemcpyHtoD ( cuScnInfo, &mScnInfo, sizeof(ScnInfo) ), "VolumeGVDB", "PrepareRender", "cuMemcpyHtoD", "cuScnInfo", mbDebug);
 

--- a/source/gvdb_library/src/gvdb_volume_gvdb.cpp
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.cpp
@@ -2494,7 +2494,7 @@ void VolumeGVDB::SaveVDB ( std::string fname )
 }
 
 // Add a search path for assets
-void VolumeGVDB::AddPath ( char* path )
+void VolumeGVDB::AddPath ( const char* path )
 {
 	mScene->AddPath ( path );
 }
@@ -3375,12 +3375,12 @@ void VolumeGVDB::writeCube (  FILE* fp, unsigned char vpix[], slong& numfaces, i
 	v[6] = vbase + vgToVert[ gv[6] ];
 	v[7] = vbase + vgToVert[ gv[7] ];
 
-	if ( vpix[1] == 0 )	{fprintf(fp, "f %d//0 %d//0 %d//0 %d//0\n", v[1], v[2], v[6], v[5] );  numfaces++; }	// x+	
-	if ( vpix[2] == 0 ) {fprintf(fp, "f %d//1 %d//1 %d//1 %d//1\n", v[0], v[3], v[7], v[4] );  numfaces++; }	// x-
-	if ( vpix[3] == 0 ) {fprintf(fp, "f %d//2 %d//2 %d//2 %d//2\n", v[2], v[3], v[7], v[6] );  numfaces++; }	// y+
-	if ( vpix[4] == 0 ) {fprintf(fp, "f %d//3 %d//3 %d//3 %d//3\n", v[1], v[0], v[4], v[5] );  numfaces++; }	// y- 
-	if ( vpix[5] == 0 )	{fprintf(fp, "f %d//4 %d//4 %d//4 %d//4\n", v[4], v[5], v[6], v[7] );  numfaces++; }	// z+
-	if ( vpix[6] == 0 ) {fprintf(fp, "f %d//5 %d//5 %d//5 %d//5\n", v[0], v[1], v[2], v[3] );  numfaces++; }	// z-	
+	if ( vpix[1] == 0 )	{fprintf(fp, "f %ld//0 %ld//0 %ld//0 %ld//0\n", v[1], v[2], v[6], v[5] );  numfaces++; }	// x+	
+	if ( vpix[2] == 0 ) {fprintf(fp, "f %ld//1 %ld//1 %ld//1 %ld//1\n", v[0], v[3], v[7], v[4] );  numfaces++; }	// x-
+	if ( vpix[3] == 0 ) {fprintf(fp, "f %ld//2 %ld//2 %ld//2 %ld//2\n", v[2], v[3], v[7], v[6] );  numfaces++; }	// y+
+	if ( vpix[4] == 0 ) {fprintf(fp, "f %ld//3 %ld//3 %ld//3 %ld//3\n", v[1], v[0], v[4], v[5] );  numfaces++; }	// y- 
+	if ( vpix[5] == 0 )	{fprintf(fp, "f %ld//4 %ld//4 %ld//4 %ld//4\n", v[4], v[5], v[6], v[7] );  numfaces++; }	// z+
+	if ( vpix[6] == 0 ) {fprintf(fp, "f %ld//5 %ld//5 %ld//5 %ld//5\n", v[0], v[1], v[2], v[3] );  numfaces++; }	// z-	
 }
 
 void VolumeGVDB::enableVerts ( int*& vgToVert, std::vector<Vector3DF>& verts, Vector3DF vm, int gv[] )

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -140,7 +140,8 @@
 		Vector3DF	thresh;
 		CUdeviceptr	transfer;
 		CUdeviceptr outbuf;
-		CUdeviceptr dbuf;		
+		CUdeviceptr dbuf;	
+		Vector3DF	dir_vec;	
 	};
 
 	// CUDA modules

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -396,7 +396,7 @@
 			void DestroyChannels ();
 			void SetChannelDefault ( int cx, int cy, int cz )	{ mDefaultAxiscnt.Set(cx,cy,cz); }
 			void SetApron ( int n )	 { mApron = n;}
-			void AddChannel ( uchar chan, int dt, int apron, int filter=F_LINEAR, int border=F_CLAMP, Vector3DI axiscnt = Vector3DI(0,0,0), bool use_tex_mem=true );
+			void AddChannel ( uchar chan, int dt, int apron, int filter=F_LINEAR, int border=F_CLAMP, Vector3DI axiscnt = Vector3DI(0,0,0), bool use_tex_mem=true, Vector4DF init_val=Vector4DF{.0f,.0f,.0f,.0f});
 			void FillChannel ( uchar chan, Vector4DF val );
 			void ClearAllChannels ();
 			void ClearChannel(uchar chan);

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -104,6 +104,8 @@
 		Vector3DF		bmax;				
 		CUtexObject		volIn[MAX_CHANNEL];
 		CUsurfObject	volOut[MAX_CHANNEL];
+		CUdeviceptr		atlas_dev_mem[MAX_CHANNEL];
+		bool			use_tex_mem[MAX_CHANNEL];
 	};
 
 	struct ALIGN(16) ScnInfo {
@@ -393,7 +395,7 @@
 			void DestroyChannels ();
 			void SetChannelDefault ( int cx, int cy, int cz )	{ mDefaultAxiscnt.Set(cx,cy,cz); }
 			void SetApron ( int n )	 { mApron = n;}
-			void AddChannel ( uchar chan, int dt, int apron, int filter=F_LINEAR, int border=F_CLAMP, Vector3DI axiscnt = Vector3DI(0,0,0) );
+			void AddChannel ( uchar chan, int dt, int apron, int filter=F_LINEAR, int border=F_CLAMP, Vector3DI axiscnt = Vector3DI(0,0,0), bool use_tex_mem=true );
 			void FillChannel ( uchar chan, Vector4DF val );
 			void ClearAllChannels ();
 			void ClearChannel(uchar chan);

--- a/source/gvdb_library/src/gvdb_volume_gvdb.h
+++ b/source/gvdb_library/src/gvdb_volume_gvdb.h
@@ -386,7 +386,7 @@
 			void SaveVDB ( std::string fname );
 			bool ImportVTK ( std::string fname, std::string field, Vector3DI& res );
 			void WriteObj ( char* fname );
-			void AddPath ( char* path );
+			void AddPath ( const char* path );
 			bool FindFile ( std::string fname, char* path );		
 			void ConvertBitmaskToNonBitmask(int levs);
 
@@ -845,7 +845,7 @@
 			Vector3DF		mPretrans, mAngs, mTrans, mScale;
 			Matrix4F		mXform, mInvXform, mInvXrot;
 
-			char*			mRendName[SHADE_MAX];
+			const char*			mRendName[SHADE_MAX];
 
 			float			m_bias;
 		};

--- a/source/gvdb_library/src/loader_OBJReader.cpp
+++ b/source/gvdb_library/src/loader_OBJReader.cpp
@@ -73,7 +73,7 @@ bool OBJReader::isMyFile( const char* filename )
 	return getExtension( filename ) == "obj";
 }
 
-bool OBJReader::LoadFile ( Model* model, char *filename, std::vector<std::string>& paths )
+bool OBJReader::LoadFile ( Model* model, const char *filename, std::vector<std::string>& paths )
 {
 	ParseFile ( filename, paths );
 

--- a/source/gvdb_library/src/loader_OBJReader.h
+++ b/source/gvdb_library/src/loader_OBJReader.h
@@ -42,7 +42,7 @@ public:
 	OBJReader();
 	virtual ~OBJReader();
 	
-	bool LoadFile ( Model* model, char *filename, std::vector<std::string>& paths );
+	bool LoadFile ( Model* model, const char *filename, std::vector<std::string>& paths );
 	bool Cleanup ();	
 	static bool isMyFile ( const char* filename );
 

--- a/source/gvdb_library/src/loader_Parser.cpp
+++ b/source/gvdb_library/src/loader_Parser.cpp
@@ -182,7 +182,7 @@ Parser::Parser() :
 
 }
 
-void Parser::ParseFile ( char *fname, std::vector<std::string>& paths ) 	
+void Parser::ParseFile ( const char *fname, std::vector<std::string>& paths ) 	
 {
 	// Check for this file in the current path, then all the search paths specified
 	char fileName[1024];
@@ -421,7 +421,7 @@ CallbackParser::CallbackParser () : Parser(), numCallbacks(0)
 }
 
 
-void CallbackParser::ParseFile ( char *filename, std::vector<std::string>& paths ) 
+void CallbackParser::ParseFile ( const char *filename, std::vector<std::string>& paths ) 
 {
 	Parser::ParseFile ( filename, paths );
 
@@ -434,7 +434,7 @@ CallbackParser::~CallbackParser()
 		free( callbackTokens[i] );
 }
 
-void CallbackParser::SetCallback( char *token, CallbackFunction func )
+void CallbackParser::SetCallback( const char *token, CallbackFunction func )
 {
 	if (numCallbacks >= 32) return;
 	

--- a/source/gvdb_library/src/loader_Parser.h
+++ b/source/gvdb_library/src/loader_Parser.h
@@ -42,7 +42,7 @@
 		Parser();
 		virtual ~Parser();
 
-		void ParseFile ( char *filename, std::vector<std::string>& paths );	
+		void ParseFile ( const char *filename, std::vector<std::string>& paths );	
 
 		// Read the next line into an internal buffer
 		char *ReadNextLine( bool discardBlanks=true );  
@@ -137,11 +137,11 @@
 		CallbackParser ();
 		virtual ~CallbackParser();
 
-		void ParseFile ( char *filename, std::vector<std::string>& paths );
+		void ParseFile ( const char *filename, std::vector<std::string>& paths );
 
 		// Add a callback to the list of token / function pairs
 		//   -> Matching with 'token' is not case sensitive.
-		void SetCallback( char *token, void(*func) () );
+		void SetCallback( const char *token, void(*func) () );
 
 		// Once the callbacks are setup, parse the file.
 		//  -> This also closes the file when done parsing

--- a/source/gvdb_library/src/string_helper.cpp
+++ b/source/gvdb_library/src/string_helper.cpp
@@ -248,7 +248,7 @@ unsigned long getFilePos ( FILE* fp )
 	return ftell ( fp );
 }
 
-bool getFileLocation ( char* filename, char* outpath, std::vector<std::string>& searchPaths )
+bool getFileLocation ( const char* filename, char* outpath, std::vector<std::string>& searchPaths )
 {
 	bool found = false;
 	FILE* fp = fopen( filename, "rb" );

--- a/source/gvdb_library/src/string_helper.h
+++ b/source/gvdb_library/src/string_helper.h
@@ -59,8 +59,8 @@
 	GVDB_API bool strEq ( std::string str, std::string str2 );
 
 	// File helpers
-	GVDB_API unsigned long getFileSize ( char* fname );
+	GVDB_API unsigned long getFileSize ( const char* fname );
 	GVDB_API unsigned long getFilePos ( FILE* fp );
-	GVDB_API bool getFileLocation ( char* filename, char* outpath, std::vector<std::string>& paths );
+	GVDB_API bool getFileLocation ( const char* filename, char* outpath, std::vector<std::string>& paths );
 
 #endif

--- a/source/sample_utils/main.h
+++ b/source/sample_utils/main.h
@@ -379,7 +379,7 @@
 	// sample-specific implementation, called by nvprintfLevel. For example to redirect the message to a specific window or part of the viewport
 	extern void sample_print(int level, const char * fmt2);
 
-	extern void checkGL( char* msg );
+	extern void checkGL( const char* msg );
 
 	// sample-specific implementation, called by nvprintf*. For example to redirect the message to a specific window or part of the viewport
 	extern void sample_print(int level, const char * fmt);

--- a/source/sample_utils/main_win.cpp
+++ b/source/sample_utils/main_win.cpp
@@ -166,7 +166,7 @@ void debugGL ( bool tf )
 	g_bARBVerbose = tf;
 }
 
-void checkGL( char* msg )
+void checkGL( const char* msg )
 {
 	GLenum errCode;	
 	errCode = glGetError();
@@ -1671,7 +1671,7 @@ void nverror ()
 	exit(-1);
 }
 
-bool getFileLocation ( char* filename, char* outpath )
+bool getFileLocation ( const char* filename, char* outpath )
 {
 	std::vector<std::string> paths;
 	paths.push_back ("./");
@@ -1681,7 +1681,7 @@ bool getFileLocation ( char* filename, char* outpath )
 	return result;
 }
 
-bool getFileLocation ( char* filename, char* outpath, std::vector<std::string> searchPaths )
+bool getFileLocation ( const char* filename, char* outpath, std::vector<std::string> searchPaths )
 {
 	bool found = false;
 	FILE* fp = fopen( filename, "rb" );

--- a/source/sample_utils/main_x11.cpp
+++ b/source/sample_utils/main_x11.cpp
@@ -566,7 +566,9 @@ void NVPWindow::setTitle(const char *title){
 
 void NVPWindow::resize_window ( int w, int h )
 {	
-
+    std::cout<<"Attempting to resize window to "<<w<<"x"<<h<<"...\n";
+    int result = XResizeWindow(m_internal->m_dpy, m_internal->m_window, w, h);
+    std::cout<<result;
 }
 
 void NVPWindow::maximize(){

--- a/source/sample_utils/main_x11.cpp
+++ b/source/sample_utils/main_x11.cpp
@@ -164,7 +164,7 @@ static void APIENTRY myOpenGLCallback(  GLenum source,
 }
 
 //------------------------------------------------------------------------------
-void checkGL( char* msg )
+void checkGL( const char* msg )
 {
     GLenum errCode;
     //const GLubyte* errString;
@@ -177,7 +177,7 @@ void checkGL( char* msg )
 
 #else
 //------------------------------------------------------------------------------
-void checkGL( char* msg ) {}
+void checkGL( const char* msg ) {}
 #endif
 
 struct WINinternal{

--- a/source/sample_utils/nv_gui.cpp
+++ b/source/sample_utils/nv_gui.cpp
@@ -94,7 +94,7 @@ void draw3D ()		{ g_2D.draw3D(); }
 
 void drawGui ( nvImg* img)		{ g_Gui.Draw( img ); }
 void clearGuis ()				{ g_Gui.Clear(); }
-int  addGui ( int x, int y, int w, int h, char* name, int gtype, int dtype, void* data, float vmin, float vmax ) { return g_Gui.AddGui ( float(x), float(y), float(w), float(h), name, gtype, dtype, data, vmin, vmax ); }
+int  addGui ( int x, int y, int w, int h, const char* name, int gtype, int dtype, void* data, float vmin, float vmax ) { return g_Gui.AddGui ( float(x), float(y), float(w), float(h), name, gtype, dtype, data, vmin, vmax ); }
 void setBackclr ( float r, float g, float b, float a )	{ return g_Gui.SetBackclr ( r,g,b,a ); }
 int  addItem ( char* name )		{ return g_Gui.AddItem ( name ); }
 int  addItem ( char* name, char* imgname ) { return g_Gui.AddItem ( name, imgname ); }
@@ -1309,7 +1309,7 @@ nvGui::nvGui ()
 	mActiveGui = -1;
 }
 
-int nvGui::AddGui ( float x, float y, float w, float h, char* name, int gtype, int dtype, void* data, float vmin, float vmax  )
+int nvGui::AddGui ( float x, float y, float w, float h, const char* name, int gtype, int dtype, void* data, float vmin, float vmax  )
 {
 	Gui g;
 

--- a/source/sample_utils/nv_gui.h
+++ b/source/sample_utils/nv_gui.h
@@ -347,7 +347,7 @@
 	class nvGui {
 	public:
 		nvGui ();
-		int		AddGui ( float x, float y, float w, float h, char* name, int gtype, int dtype, void* data, float vmin, float vmax );
+		int		AddGui ( float x, float y, float w, float h, const char* name, int gtype, int dtype, void* data, float vmin, float vmax );
 		int		AddItem ( char* name, char* imgname = 0x0 );
 		void    SetBackclr ( float r, float g, float b, float a );
 		bool	guiChanged ( int n );
@@ -401,7 +401,7 @@
 	extern nvGui	g_Gui;
 	extern void		drawGui ( nvImg* img );	
 	extern void     clearGuis ();
-	extern int		addGui ( int x, int y, int w, int h, char* name, int gtype, int dtype, void* data, float vmin, float vmax );
+	extern int		addGui ( int x, int y, int w, int h, const char* name, int gtype, int dtype, void* data, float vmin, float vmax );
 	extern int		addItem ( char* name, char* imgname = 0x0 );
 	extern void		setBackclr ( float r, float g, float b, float a );
 	extern std::string guiItemName ( int n, int v );


### PR DESCRIPTION
Merge from the `feature/device_mem_extension` branch on icoderaven's fork:
Adds support for using standard global memory (which supports atomic write) for specific channels' atlas storage instead of 3D textures.